### PR TITLE
Put sections in alphabetical order

### DIFF
--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -6,71 +6,31 @@
     <p>Sections:</p>
   </div>
   <nav class="sidebar-nav">
-    <a class="sidebar-nav-item {{ispage pages/plotting/*}}active{{end}}" href="/pages/plotting/">Plotting
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/differentiation/*}}active{{end}}"
-      href="/pages/differentiation/">Differentiation
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/uncertainty_propagation/*}}active{{end}}"
-      href="/pages/uncertainty_propagation/">Uncertainty Propagation
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/machine_learning/*}}active{{end}}" href="/pages/machine_learning/">Machine
-      Learning
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/machine_learning_datasets/*}}active{{end}}"
-      href="/pages/machine_learning_datasets/">Machine Learning Datasets
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/neural_networks/*}}active{{end}}" href="/pages/neural_networks/">Neural
-      Networks
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/notebooks/*}}active{{end}}" href="/pages/notebooks/">Notebooks
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/multithreading/*}}active{{end}}"
-      href="/pages/multithreading/">Multithreading
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/loop_acceleration/*}}active{{end}}" href="/pages/loop_acceleration/">Loop
-      Acceleration
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/dataframes/*}}active{{end}}" href="/pages/dataframes/">Dataframes
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/linear_solvers/*}}active{{end}}" href="/pages/linear_solvers/">Linear
-      Solvers
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/nonlinear_solvers/*}}active{{end}}" href="/pages/nonlinear_solvers/">Nonlinear
-      Solvers
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/saving_files/*}}active{{end}}" href="/pages/saving_files/">Saving Files
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/redefinable_structs/*}}active{{end}}"
-      href="/pages/redefinable_structs/">Redefinable Structs
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/signal_processing/*}}active{{end}}"
-      href="/pages/signal_processing/">Signal Processing
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/probabilistic_programming/*}}active{{end}}"
-      href="/pages/probabilistic_programming/">Probabilistic Programming
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/triangulations_or_tessellations/*}}active{{end}}"
-      href="/pages/triangulations_or_tessellations/">Triangulations / tessellations
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/piping/*}}active{{end}}" href="/pages/piping/"> Piping
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/graphs/*}}active{{end}}" href="/pages/graphs/"> Graphs
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/static_websites/*}}active{{end}}" href="/pages/static_websites/"> Static
-      Websites
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/web_apps/*}}active{{end}}" href="/pages/web_apps/"> Web Apps
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/control_systems/*}}active{{end}}" href="/pages/control_systems/"> Control
-      Systems
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/units/*}}active{{end}}" href="/pages/units/"> Units
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/einsum/*}}active{{end}}" href="/pages/einsum/"> Einsum
-    </a>
-    <a class="sidebar-nav-item {{ispage pages/interoperability/*}}active{{end}}" href="/pages/interoperability/"> Interoperability
-    </a>
+    <a class="sidebar-nav-item {{ispage pages/plotting/*}}active{{end}}" href="/pages/plotting/">Plotting</a>
+    <a class="sidebar-nav-item {{ispage pages/differentiation/*}}active{{end}}" href="/pages/differentiation/">Differentiation</a>
+    <a class="sidebar-nav-item {{ispage pages/uncertainty_propagation/*}}active{{end}}" href="/pages/uncertainty_propagation/">Uncertainty Propagation</a>
+    <a class="sidebar-nav-item {{ispage pages/machine_learning/*}}active{{end}}" href="/pages/machine_learning/">Machine Learning</a>
+    <a class="sidebar-nav-item {{ispage pages/machine_learning_datasets/*}}active{{end}}" href="/pages/machine_learning_datasets/">Machine Learning Datasets</a>
+    <a class="sidebar-nav-item {{ispage pages/neural_networks/*}}active{{end}}" href="/pages/neural_networks/">Neural Networks</a>
+    <a class="sidebar-nav-item {{ispage pages/notebooks/*}}active{{end}}" href="/pages/notebooks/">Notebooks</a>
+    <a class="sidebar-nav-item {{ispage pages/multithreading/*}}active{{end}}" href="/pages/multithreading/">Multithreading</a>
+    <a class="sidebar-nav-item {{ispage pages/loop_acceleration/*}}active{{end}}" href="/pages/loop_acceleration/">Loop Acceleration</a>
+    <a class="sidebar-nav-item {{ispage pages/dataframes/*}}active{{end}}" href="/pages/dataframes/">Dataframes</a>
+    <a class="sidebar-nav-item {{ispage pages/linear_solvers/*}}active{{end}}" href="/pages/linear_solvers/">Linear Solvers</a>
+    <a class="sidebar-nav-item {{ispage pages/nonlinear_solvers/*}}active{{end}}" href="/pages/nonlinear_solvers/">Nonlinear Solvers</a>
+    <a class="sidebar-nav-item {{ispage pages/saving_files/*}}active{{end}}" href="/pages/saving_files/">Saving Files</a>
+    <a class="sidebar-nav-item {{ispage pages/redefinable_structs/*}}active{{end}}" href="/pages/redefinable_structs/">Redefinable Structs</a>
+    <a class="sidebar-nav-item {{ispage pages/signal_processing/*}}active{{end}}" href="/pages/signal_processing/">Signal Processing</a>
+    <a class="sidebar-nav-item {{ispage pages/probabilistic_programming/*}}active{{end}}" href="/pages/probabilistic_programming/">Probabilistic Programming</a>
+    <a class="sidebar-nav-item {{ispage pages/triangulations_or_tessellations/*}}active{{end}}" href="/pages/triangulations_or_tessellations/">Triangulations and Tessellations</a>
+    <a class="sidebar-nav-item {{ispage pages/piping/*}}active{{end}}" href="/pages/piping/">Piping</a>
+    <a class="sidebar-nav-item {{ispage pages/graphs/*}}active{{end}}" href="/pages/graphs/">Graphs</a>
+    <a class="sidebar-nav-item {{ispage pages/static_websites/*}}active{{end}}" href="/pages/static_websites/">Static Websites</a>
+    <a class="sidebar-nav-item {{ispage pages/web_apps/*}}active{{end}}" href="/pages/web_apps/">Web Apps</a>
+    <a class="sidebar-nav-item {{ispage pages/control_systems/*}}active{{end}}" href="/pages/control_systems/">Control Systems</a>
+    <a class="sidebar-nav-item {{ispage pages/units/*}}active{{end}}" href="/pages/units/">Units</a>
+    <a class="sidebar-nav-item {{ispage pages/einsum/*}}active{{end}}" href="/pages/einsum/">Einsum</a>
+    <a class="sidebar-nav-item {{ispage pages/interoperability/*}}active{{end}}" href="/pages/interoperability/">Interoperability</a>
 
 
 

--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -6,31 +6,31 @@
     <p>Sections:</p>
   </div>
   <nav class="sidebar-nav">
-    <a class="sidebar-nav-item {{ispage pages/plotting/*}}active{{end}}" href="/pages/plotting/">Plotting</a>
+    <a class="sidebar-nav-item {{ispage pages/control_systems/*}}active{{end}}" href="/pages/control_systems/">Control Systems</a>
+    <a class="sidebar-nav-item {{ispage pages/dataframes/*}}active{{end}}" href="/pages/dataframes/">Dataframes</a>
     <a class="sidebar-nav-item {{ispage pages/differentiation/*}}active{{end}}" href="/pages/differentiation/">Differentiation</a>
-    <a class="sidebar-nav-item {{ispage pages/uncertainty_propagation/*}}active{{end}}" href="/pages/uncertainty_propagation/">Uncertainty Propagation</a>
+    <a class="sidebar-nav-item {{ispage pages/einsum/*}}active{{end}}" href="/pages/einsum/">Einsum</a>
+    <a class="sidebar-nav-item {{ispage pages/graphs/*}}active{{end}}" href="/pages/graphs/">Graphs</a>
+    <a class="sidebar-nav-item {{ispage pages/interoperability/*}}active{{end}}" href="/pages/interoperability/">Interoperability</a>
+    <a class="sidebar-nav-item {{ispage pages/linear_solvers/*}}active{{end}}" href="/pages/linear_solvers/">Linear Solvers</a>
+    <a class="sidebar-nav-item {{ispage pages/loop_acceleration/*}}active{{end}}" href="/pages/loop_acceleration/">Loop Acceleration</a>
     <a class="sidebar-nav-item {{ispage pages/machine_learning/*}}active{{end}}" href="/pages/machine_learning/">Machine Learning</a>
     <a class="sidebar-nav-item {{ispage pages/machine_learning_datasets/*}}active{{end}}" href="/pages/machine_learning_datasets/">Machine Learning Datasets</a>
-    <a class="sidebar-nav-item {{ispage pages/neural_networks/*}}active{{end}}" href="/pages/neural_networks/">Neural Networks</a>
-    <a class="sidebar-nav-item {{ispage pages/notebooks/*}}active{{end}}" href="/pages/notebooks/">Notebooks</a>
     <a class="sidebar-nav-item {{ispage pages/multithreading/*}}active{{end}}" href="/pages/multithreading/">Multithreading</a>
-    <a class="sidebar-nav-item {{ispage pages/loop_acceleration/*}}active{{end}}" href="/pages/loop_acceleration/">Loop Acceleration</a>
-    <a class="sidebar-nav-item {{ispage pages/dataframes/*}}active{{end}}" href="/pages/dataframes/">Dataframes</a>
-    <a class="sidebar-nav-item {{ispage pages/linear_solvers/*}}active{{end}}" href="/pages/linear_solvers/">Linear Solvers</a>
+    <a class="sidebar-nav-item {{ispage pages/neural_networks/*}}active{{end}}" href="/pages/neural_networks/">Neural Networks</a>
     <a class="sidebar-nav-item {{ispage pages/nonlinear_solvers/*}}active{{end}}" href="/pages/nonlinear_solvers/">Nonlinear Solvers</a>
-    <a class="sidebar-nav-item {{ispage pages/saving_files/*}}active{{end}}" href="/pages/saving_files/">Saving Files</a>
-    <a class="sidebar-nav-item {{ispage pages/redefinable_structs/*}}active{{end}}" href="/pages/redefinable_structs/">Redefinable Structs</a>
-    <a class="sidebar-nav-item {{ispage pages/signal_processing/*}}active{{end}}" href="/pages/signal_processing/">Signal Processing</a>
-    <a class="sidebar-nav-item {{ispage pages/probabilistic_programming/*}}active{{end}}" href="/pages/probabilistic_programming/">Probabilistic Programming</a>
-    <a class="sidebar-nav-item {{ispage pages/triangulations_or_tessellations/*}}active{{end}}" href="/pages/triangulations_or_tessellations/">Triangulations and Tessellations</a>
+    <a class="sidebar-nav-item {{ispage pages/notebooks/*}}active{{end}}" href="/pages/notebooks/">Notebooks</a>
     <a class="sidebar-nav-item {{ispage pages/piping/*}}active{{end}}" href="/pages/piping/">Piping</a>
-    <a class="sidebar-nav-item {{ispage pages/graphs/*}}active{{end}}" href="/pages/graphs/">Graphs</a>
+    <a class="sidebar-nav-item {{ispage pages/plotting/*}}active{{end}}" href="/pages/plotting/">Plotting</a>
+    <a class="sidebar-nav-item {{ispage pages/probabilistic_programming/*}}active{{end}}" href="/pages/probabilistic_programming/">Probabilistic Programming</a>
+    <a class="sidebar-nav-item {{ispage pages/redefinable_structs/*}}active{{end}}" href="/pages/redefinable_structs/">Redefinable Structs</a>
+    <a class="sidebar-nav-item {{ispage pages/saving_files/*}}active{{end}}" href="/pages/saving_files/">Saving Files</a>
+    <a class="sidebar-nav-item {{ispage pages/signal_processing/*}}active{{end}}" href="/pages/signal_processing/">Signal Processing</a>
     <a class="sidebar-nav-item {{ispage pages/static_websites/*}}active{{end}}" href="/pages/static_websites/">Static Websites</a>
-    <a class="sidebar-nav-item {{ispage pages/web_apps/*}}active{{end}}" href="/pages/web_apps/">Web Apps</a>
-    <a class="sidebar-nav-item {{ispage pages/control_systems/*}}active{{end}}" href="/pages/control_systems/">Control Systems</a>
+    <a class="sidebar-nav-item {{ispage pages/triangulations_or_tessellations/*}}active{{end}}" href="/pages/triangulations_or_tessellations/">Triangulations and Tessellations</a>
+    <a class="sidebar-nav-item {{ispage pages/uncertainty_propagation/*}}active{{end}}" href="/pages/uncertainty_propagation/">Uncertainty Propagation</a>
     <a class="sidebar-nav-item {{ispage pages/units/*}}active{{end}}" href="/pages/units/">Units</a>
-    <a class="sidebar-nav-item {{ispage pages/einsum/*}}active{{end}}" href="/pages/einsum/">Einsum</a>
-    <a class="sidebar-nav-item {{ispage pages/interoperability/*}}active{{end}}" href="/pages/interoperability/">Interoperability</a>
+    <a class="sidebar-nav-item {{ispage pages/web_apps/*}}active{{end}}" href="/pages/web_apps/">Web Apps</a>
 
 
 

--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -16,6 +16,7 @@
     <a class="sidebar-nav-item {{ispage pages/loop_acceleration/*}}active{{end}}" href="/pages/loop_acceleration/">Loop Acceleration</a>
     <a class="sidebar-nav-item {{ispage pages/machine_learning/*}}active{{end}}" href="/pages/machine_learning/">Machine Learning</a>
     <a class="sidebar-nav-item {{ispage pages/machine_learning_datasets/*}}active{{end}}" href="/pages/machine_learning_datasets/">Machine Learning Datasets</a>
+    <a class="sidebar-nav-item {{ispage pages/metrics/*}}active{{end}}" href="/pages/metrics/">Metrics</a>
     <a class="sidebar-nav-item {{ispage pages/multithreading/*}}active{{end}}" href="/pages/multithreading/">Multithreading</a>
     <a class="sidebar-nav-item {{ispage pages/neural_networks/*}}active{{end}}" href="/pages/neural_networks/">Neural Networks</a>
     <a class="sidebar-nav-item {{ispage pages/nonlinear_solvers/*}}active{{end}}" href="/pages/nonlinear_solvers/">Nonlinear Solvers</a>
@@ -23,11 +24,11 @@
     <a class="sidebar-nav-item {{ispage pages/piping/*}}active{{end}}" href="/pages/piping/">Piping</a>
     <a class="sidebar-nav-item {{ispage pages/plotting/*}}active{{end}}" href="/pages/plotting/">Plotting</a>
     <a class="sidebar-nav-item {{ispage pages/probabilistic_programming/*}}active{{end}}" href="/pages/probabilistic_programming/">Probabilistic Programming</a>
-    <a class="sidebar-nav-item {{ispage pages/redefinable_structs/*}}active{{end}}" href="/pages/redefinable_structs/">Redefinable Structs</a>
-    <a class="sidebar-nav-item {{ispage pages/saving_files/*}}active{{end}}" href="/pages/saving_files/">Saving Files</a>
+    <a class="sidebar-nav-item {{ispage pages/redefinable_structs/*}}active{{end}}" href="/pages/redefinable_structs/">Redefinable Structs </a>
+    <a class="sidebar-nav-item {{ispage pages/saving_files/*}}active{{end}}" href="/pages/saving_files/">Saving Files </a>
     <a class="sidebar-nav-item {{ispage pages/signal_processing/*}}active{{end}}" href="/pages/signal_processing/">Signal Processing</a>
     <a class="sidebar-nav-item {{ispage pages/static_websites/*}}active{{end}}" href="/pages/static_websites/">Static Websites</a>
-    <a class="sidebar-nav-item {{ispage pages/triangulations_or_tessellations/*}}active{{end}}" href="/pages/triangulations_or_tessellations/">Triangulations and Tessellations</a>
+    <a class="sidebar-nav-item {{ispage pages/triangulations_or_tessellations/*}}active{{end}}" href="/pages/triangulations_or_tessellations/">Triangulations / Tessellations</a>
     <a class="sidebar-nav-item {{ispage pages/uncertainty_propagation/*}}active{{end}}" href="/pages/uncertainty_propagation/">Uncertainty Propagation</a>
     <a class="sidebar-nav-item {{ispage pages/units/*}}active{{end}}" href="/pages/units/">Units</a>
     <a class="sidebar-nav-item {{ispage pages/web_apps/*}}active{{end}}" href="/pages/web_apps/">Web Apps</a>
@@ -35,9 +36,8 @@
 
 
 
+
     <!---
-    <a class="sidebar-nav-item {{ispage menu2/*}}active{{end}}" href="/menu2/">More goodies</a>
-    <a class="sidebar-nav-item {{ispage menu3/*}}active{{end}}" href="/menu3/">Tags</a>
     -->
   </nav>
   <div class="sidebar-item">

--- a/pages/triangulations_or_tessellations.md
+++ b/pages/triangulations_or_tessellations.md
@@ -1,4 +1,4 @@
-# Triangulations / Tessellations
+# Triangulations and Tessellations
 
 Two common methods for partitioning space into individual elements are [_triangulations_](https://en.wikipedia.org/wiki/Point-set_triangulation) and [_tessellations_](https://en.wikipedia.org/wiki/Voronoi_diagram). This section is dedicated to packages that implement such methods.
 


### PR DESCRIPTION
It might be easier if the sections in the sidebar are in alphabetical order.

I used this script to sort them (there's probably a better way :-)).

```julia
cd(@__DIR__)
lines = Vector{String}(undef, 0)
page_lines = Vector{Int}(undef, 0)
page_names = Vector{String}(undef, 0)
ignore = Set(["More goodies", "Tags"])
open("sidebar.html", "r") do io 
    for line in eachline(io)
        push!(lines, line)
        if occursin("sidebar-nav-item", line)
            page_name = match(r"<a[^>]*>(.*?)</a>", line).captures[1]
            page_name ∈ ignore && continue
            push!(page_lines, length(lines))
            push!(page_names, page_name)
        end
    end
end
sort_idx = sortperm(page_names)
lines[page_lines] = lines[page_lines[sort_idx]]
open("sidebar.html", "w") do io
    for line in lines
        println(io, line)
    end
end
```