### PR TITLE
Remove mistakenly added `.vscode/settings.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __site/
 .DS_Store
+.vscode
 node_modules/
 package-lock.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "workbench.colorTheme": "Default Dark+"
-}


### PR DESCRIPTION
One can ignore `.vscode` in `~/.gitignore_global`, but it would be okay to ignore in this repository because we already have `.DS_Store` in `.gitignore`.