### PR TITLE
Add star history

### DIFF
--- a/_css/jtd.css
+++ b/_css/jtd.css
@@ -632,6 +632,11 @@ td {
   padding-left: 0%;
 }
 
+.franklin-content .star-history img {
+  width: 90%;
+  text-align: center;
+  padding-left: 5%;
+}
 
 /* ==================================================================
     KATEX

--- a/pages/bspline.md
+++ b/pages/bspline.md
@@ -13,11 +13,11 @@ There are several Julia packages for [B-spline](https://en.wikipedia.org/wiki/B-
 ### BSplines.jl
 {{badge BSplines}}
 
-### BSplineKit.jl
-{{badge BSplineKit}}
-
 ### BasicBSpline.jl
 {{badge BasicBSpline}}
+
+### BSplineKit.jl
+{{badge BSplineKit}}
 
 ### NURBS.jl
 {{badge NURBS}}

--- a/pages/bspline.md
+++ b/pages/bspline.md
@@ -21,3 +21,6 @@ There are several Julia packages for [B-spline](https://en.wikipedia.org/wiki/B-
 
 ### NURBS.jl
 {{badge NURBS}}
+
+## Star History
+{{star_history BSplines BasicBSpline BSplineKit NURBS}}

--- a/pages/einsum.md
+++ b/pages/einsum.md
@@ -6,33 +6,37 @@ title = "Einsum"
 In linear algebra and mathematical physics, there is a notational convention called [Einstein Notation](https://en.wikipedia.org/wiki/Einstein_notation). The python package numpy implements a function called [einsum](https://numpy.org/doc/stable/reference/generated/numpy.einsum.html), which is the first hit when googling the term. Several Julia packages exists that implement einsum functionality.
 \toc
 
-## Tullio.jl
+## Packages
+### Tullio.jl
 {{badge Tullio}}
 This package implements a macro `@tullio`, which it describes as
 > a very flexible einsum macro. It understands many array operations written in index notation -- not just matrix multiplication and permutations, but also convolutions, stencils, scatter/gather, and broadcasting.
 
-## Einsum.jl
+### Einsum.jl
 {{badge Einsum}}
 From README.md of this package:
 > This package exports a single macro @einsum, which implements similar notation to the Einstein summation convention to flexibly specify operations on Julia Arrays, similar to numpy's einsum function (but more flexible!).
 
-## OMEinsum.jl
+### OMEinsum.jl
 {{badge OMEinsum}}
 From README.md of this package:
 > This is a repository for the Google Summer of Code project on Differentiable Tensor Networks. It implements one function that both computer scientists and physicists love, the Einstein summation
 
-## TensorOperations.jl
+### TensorOperations.jl
 {{badge TensorOperations}}
 
-## TensorCast.jl
+### TensorCast.jl
 {{badge TensorCast}}
 
-## ArrayMeta.jl
+### ArrayMeta.jl
 {{badge ArrayMeta}}
 
 ArrayMeta.jl exists, but the package is not maintained and registered.
 
-## Tortilla.jl
+### Tortilla.jl
 Tortilla.jl was announced in JuliaCon2018, but the package is not public yet.
 
 * [For Loops 2.0: Index Notation and the Future of Tensor Compilers | Willow Ahrens | JuliaCon 2018](https://www.youtube.com/watch?v=Rp7sTl9oPNI)
+
+## Star History
+{{star_history Tullio Einsum OMEinsum TensorOperations TensorCast ArrayMeta}}

--- a/pages/piping.md
+++ b/pages/piping.md
@@ -9,16 +9,20 @@ The different packages that implement more advanced piping functionality are lis
 
 \toc
 
-## Chain.jl
+## Packages
+### Chain.jl
 {{badge Chain}}
 [Chain.jl](https://github.com/jkrumbiegel/Chain.jl) is the most starred package that purely implements piping functionality. It describes itself as follows:
 > A Julia package for piping a value through a series of transformation expressions using a more convenient syntax than Julia's native piping functionality.
 
-## Lazy.jl
+### Lazy.jl
 {{badge Lazy}}
 Lazy.jl implements a lot of other functionality, but discussed piping in particular under [this section](https://github.com/MikeInnes/Lazy.jl#macros) of the readme
 
-## Pipe.jl
+### Pipe.jl
 {{badge Pipe}}
 [Pipe.jl](https://github.com/oxinabox/Pipe.jl) describes itself as follows:
 > An enhancement to julia piping syntax
+
+## Star history
+{{star_history Chain Lazy Pipe}}

--- a/utils.jl
+++ b/utils.jl
@@ -116,10 +116,10 @@ function hfun_star_history(args)
   repos = [chopprefix(repolink, "https://github.com/") for repolink in repolinks]
   join(repos, "&amp;")
   """
-  <p>
+  <div class="star-history">
   <a href="https://star-history.com/#$(join(repos, "&amp;"))&amp;Date"><img src="https://api.star-history.com/svg?repos=$(join(repos, ","))&amp;type=Date" alt="Star History Chart">
   </a>
-  </p>
+  </div>
   """
 end
 

--- a/utils.jl
+++ b/utils.jl
@@ -109,6 +109,20 @@ function hfun_badge(args)
   """
 end
 
+function hfun_star_history(args)
+  pkgnames = args
+  pkginfos = [PKGINFOS[pkgname] for pkgname in pkgnames]
+  repolinks = [pkginfo.repolink for pkginfo in pkginfos]
+  repos = [chopprefix(repolink, "https://github.com/") for repolink in repolinks]
+  join(repos, "&amp;")
+  """
+  <p>
+  <a href="https://star-history.com/#$(join(repos, "&amp;"))&amp;Date"><img src="https://api.star-history.com/svg?repos=$(join(repos, ","))&amp;type=Date" alt="Star History Chart">
+  </a>
+  </p>
+  """
+end
+
 function hfun_bar(vname)
   val = Meta.parse(vname[1])
   return round(sqrt(val), digits=2)


### PR DESCRIPTION
This PR adds star history like this:

![image](https://github.com/JuliaPackageComparisons/JuliaPackageComparisons.github.io/assets/7488140/4e054615-0f9b-44ac-b9a9-8d2b27d73dc8)

The quality of Julia package should be measured not by the number of stars it has, but by its functionality, ease of use, and the correctness of its design. Additionally, it's important to recognize that the objectives of packages are not always identical and often involve trade-offs.

On the other hand, in situations where the comparison of packages is not sufficiently clear and well-documented, the history of stars can be useful.

When generating documentation with Franklin.jl, it would be more beneficial and of higher priority to create a system that actually runs the package's code for comparison. This would be truly useful to people. However, since implementing star history was easy, I decided to give it a try.
