### PR TITLE
Add section on lunr search.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -59,13 +59,29 @@ If you enter that folder (`cd JuliaPackageComparisons.github.io`), you can now o
 
 ```bash
 cd JuliaPackageComparisons.github.io/docs
-julia --project=. -e 'using Pkg; Pkg.instantiate(); using Franklin; lunr(); serve()'
+julia --project=. -e 'using Pkg; Pkg.instantiate(); using Franklin; serve()'
 ```
 
 You default browser should open a new tab at `http://localhost:8000/`, showing the locally hosted page.
 Changes you make to the content will be automatically detected, and the generated page will be updated in real-time as you run the above command.
 After having made the changes you want, you can commit you changes, push them to github, and then use the GitHub web page to open up a pull-request to make you changes in the original repository.
 Relevant git commands are `git commit` and `git push`, but if that is also new to you, you should probably google how to use git (a version control system) and GitHub (a website and hosting service) first.
+
+#### Lunr search
+To also run the `lunr` based search locally, you need to have `npm` and `nodejs` installed as well as the `npm` packages `lunr` and `cheerio`. See [Franklin.jl docs](https://franklinjl.org/extras/lunr/index.html#add_search_with_lunr):
+
+```bash
+> sudo install npm # installs 387 packages!
+> npm install lunr
+> npm install cheerio
+```
+
+Then serve the site locally with `lunr`:
+
+```bash
+cd JuliaPackageComparisons.github.io/docs
+julia --project=. -e 'using Pkg; Pkg.instantiate(); using Franklin; lunr(); serve()'
+```
 
 ### Update existing content
 TODO: write guide


### PR DESCRIPTION
The command for building locally:

```bash
cd JuliaPackageComparisons.github.io/docs
julia --project=. -e 'using Pkg; Pkg.instantiate(); using Franklin; lunr(); serve()'
```

gives an error on a system without `lunr` installed.

This PR fixes this by

1. Removing `lunr()` from the first build locally example.
2. Adds a new section on installing `lunr` and restoring the call there.
