### PR TITLE
Add JuliaPhysics as index page on physics

### DIFF
--- a/docs/comparisons/physics/index.md
+++ b/docs/comparisons/physics/index.md
@@ -1,0 +1,14 @@
++++
+title = "JuliaPhysics Organization"
++++
+
+# JuliaPhysics Organization
+@@badge ![JuliaPhysics](https://avatars.githubusercontent.com/u/29034810?s=100&v=4) @@ 
+There is a [JuliaPhysics](https://github.com/JuliaPhysics) organization that hosts a number of physics related packages.
+
+This includes:
+
+* [Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl). Error propagation calculator and library for physical measurements.
+* [PhysicalConstants.jl](https://github.com/JuliaPhysics/PhysicalConstants.jl). Collection of fundamental physical constants with uncertainties. 
+* [PeriodicTable.jl](https://github.com/JuliaPhysics/PeriodicTable.jl). Periodic Table for Julians! 🔥
+* [PhysicsTutorials.jl](https://github.com/JuliaPhysics/PhysicsTutorials.jl). A collection of physics tutorials for the Julia programming language.


### PR DESCRIPTION
Mentioning the JuliaPhysics organization.
