### PR TITLE
Enable non-standard docslink

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -124,7 +124,8 @@ The `PkgInfo` struct has seven fields, and can be defined with kwargs:
 * `docslink` (optional, default: `"https://$username.github.io/$pkgname.jl"`)
     * URL to the documentation.
     * Set `nothing` if the package does not have documentation.
-    * Note that `$docslink/dev` and `$docslink/stable` will be used in the documentation.
+    * By default both `$docslink/dev` and `$docslink/stable` will be used in the documentation.
+    * To get only a single documentation link, set a `docslink` that ends on "/". Then that URL is used as link to the docs (e.g. `docslink="https://eben60.github.io/Mendeleev.jl/"`).
 * `codecovlink` (optional, default: `"https://codecov.io/gh/$username/$pkgname.jl"`)
     * URL to codecov page.
     * Set `nothing` if the repository does not use CodeCov.

--- a/docs/utils.jl
+++ b/docs/utils.jl
@@ -20,12 +20,12 @@ const PKGINFOS = [
     PkgInfo(pkgname="Chain", username="jkrumbiegel", branch="master", docslink=nothing, codecovlink=nothing),
     PkgInfo(pkgname="Lazy", username="MikeInnes", branch="master", docslink=nothing, codecovlink=nothing),
     PkgInfo(pkgname="Pipe", username="oxinabox", branch="master", docslink=nothing, codecovlink=nothing),
-    PkgInfo(pkgname="Unitful", username="PainterQubits", branch="master"),
+    PkgInfo(pkgname="Unitful", username="JuliaPhysics", branch="master"),
     PkgInfo(pkgname="DynamicQuantities", username="SymbolicML", codecovlink=nothing),
     PkgInfo(pkgname="UnitSystems", username="chakravala", branch="master", docslink=nothing),
-    PkgInfo(pkgname="Genie", username="GenieFramework", branch="master", codecovlink=nothing),
-    PkgInfo(pkgname="Oxygen", username="ndortega", branch="master"),
-    PkgInfo(pkgname="Bonito", username="SimonDanisch", branch="master"),
+    PkgInfo(pkgname="Genie", username="GenieFramework", branch="master", codecovlink=nothing, docslink="https://GenieFramework.github.io/Genie.jl/dev/"),
+    PkgInfo(pkgname="Oxygen", username="OxygenFramework", branch="master"),
+    PkgInfo(pkgname="Bonito", username="SimonDanisch", branch="master", docslink="https://SimonDanisch.github.io/Bonito.jl/stable/"),
     PkgInfo(pkgname="Plots", username="JuliaPlots", branch="master", docslink="https://docs.juliaplots.org/", codecovlink=nothing),
     PkgInfo(pkgname="Makie", username="MakieOrg", branch="master", docslink="https://docs.makie.org/", codecovlink=nothing),
     PkgInfo(pkgname="AlgebraOfGraphics", username="MakieOrg", branch="master", codecovlink=nothing),
@@ -71,7 +71,7 @@ const PKGINFOS = [
     PkgInfo(pkgname="TetGen", username="JuliaGeometry", branch="master"),
     PkgInfo(pkgname="GMT", username="GenericMappingTools", branch="master"),
     PkgInfo(pkgname="PkgTemplates", username="JuliaCI", branch="master"),
-    PkgInfo(pkgname="PkgSkeleton", username="tpapp", branch="master"),
+    PkgInfo(pkgname="PkgSkeleton", username="tpapp", branch="master", docslink=nothing),
     PkgInfo(pkgname="Pkg", username="JuliaLang", branch="master"),
     PkgInfo(pkgname="PyCall", username="JuliaPy", branch="master"),
     PkgInfo(pkgname="PythonCall", username="JuliaPy"),
@@ -170,9 +170,14 @@ function hfun_badge(args)
   codecovlink = pkginfo.codecovlink
   registered = pkginfo.registered
 
-  html_docs = isnothing(docslink) ? "" : """
-  <a href="$docslink/stable"><img src="https://img.shields.io/badge/docs-stable-blue.svg" alt="Stable"></a>
-  <a href="$docslink/dev"><img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Dev"></a>
+  docreg = r".*/([^/]+)/$"
+  isnothing(docslink) || (docmatch = match(docreg, docslink))
+  html_docs = isnothing(docslink) ? "" :
+      isnothing(docmatch) ? """
+      <a href="$docslink/stable"><img src="https://img.shields.io/badge/docs-stable-blue.svg" alt="Stable"></a>
+      <a href="$docslink/dev"><img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Dev"></a>
+      """ : """
+  <a href="$docslink"><img src="https://img.shields.io/badge/docs-$(docmatch[1])-blue.svg" alt="Doc"></a>
   """
   html_codecov = isnothing(codecovlink) ? "" : """
   <a href="$codecovlink"><img src="$codecovlink/branch/$branch/graph/badge.svg" alt="Coverage"></a>


### PR DESCRIPTION
Fixes #119 

Also updates PkgInfo of 
* Unitful
* Oxygen

This works pretty well.

It makes it possible to support sites that have only a single doc link without needing to update any existing docslinks.

Updated PkgInfo of Unitful and Oxigen as they have moved into organizations.