### PR TITLE
Deprecate JSON3. 

### DIFF
--- a/docs/comparisons/dataio/fileio.md
+++ b/docs/comparisons/dataio/fileio.md
@@ -190,7 +190,7 @@ JSON.jl v0.21 or JSON3.jl](https://juliaio.github.io/JSON.jl/stable/migrate/).
 
 It also includes a `vendor/` directory containing a simplified,
 no-dependency JSON parser (`JSONX`) that can be vendored (copied) into other
-projects. See the [vendor README](vendor/README.md) for details.
+projects. See the [vendor README](https://github.com/JuliaIO/JSON.jl/blob/master/vendor/README.md) for details.
 
 #### JSON2.jl
 {{badge JSON2}}


### PR DESCRIPTION
Update to recommend JSON.jl over JSON3 as recommended by the README of https://github.com/quinnj/JSON3.jl
Fixes #146